### PR TITLE
Substituição de icon por "Sim", na tabela de CEME e mais

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ E como é para veículos elétricos, não há taxa audiovisual, etc.
 | Via Verde Electric | Fixo | Sim |  |
 | Cartão EDP Charge | Fixo | Sim |  |
 | Continente Plug & Charge | Fixo |  | Sim |
-| Miio | Fixo | Sim |  |
+| Miio | Indexado | Sim |  |
 
 ## Links Úteis
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Em alguns casos, pode ser cobrado em kWh da energia fornecida. Em casos extremos
 
 Parece complicado (e caro), não é? Vamos a um exemplo:
 
-A taxa OPC (o que explora o posto, ou seja, pagas por lá estar estacionado) em carregadores CCS2 de 50kW ou mais varia entre 0,05€/min e 0,40€/min (no carregador da Moon Power em Lisboa) e 0,07€/kWh e 0,512€/kWh (da IONITY, os postos mais caros do país, mas capazes de 350 kW ou 400 kW).  
+A taxa OPC (o que explora o posto, ou seja, pagas por lá estar estacionado) em carregadores CCS2 de 50kW ou mais varia entre 0,05€/min e 0,40€/min (no carregador da Moon Power, em Lisboa), 0,085€/kWh (em postos da Repsol) e 0,07€/kWh e 0,512€/kWh (da IONITY, os postos mais caros do país, mas capazes de 350 kW ou 400 kW).  
 A isto junta-se normalmente ~0,30€ (acresce IVA) por sessão de carregamento.
 
 A EDP e o LIDL são quem mais postos explora no país. A EDP normalmente cobra 0,09€/min e o LIDL 0,08€/min, tornando-os os mais comuns e geralmente mais económicos. Acresce IVA.

--- a/README.md
+++ b/README.md
@@ -200,17 +200,17 @@ E como é para veículos elétricos, não há taxa audiovisual, etc.
 
 | CEME  | Tipo de tarifa | EUR/kWh | EUR/min |
 | ------------- | ------------- | ------------- | ------------- |
-| LUZiGÁS | Indexado (cliente) | :star:  |  |
-| LUZiGÁS | Indexado (não cliente) | :star:  |  |
-| High Green Power | Fixo | :star:  |  |
-| Tesla | Fixo | :star: |  |
-| ACP Electric by EVIO - sócio ACP | Fixo | :star:  |  |
-| EVIO | Fixo | :star:  |  |
-| Prio Electric | Fixo | :star:  | :star: |
-| Via Verde Electric | Fixo | :star: |  |
-| Cartão EDP Charge | Fixo | :star: |  |
-| Continente Plug & Charge | Fixo |  | :star: |
-| Miio | Fixo | :star: |  |
+| LUZiGÁS | Indexado (cliente) | Sim  |  |
+| LUZiGÁS | Indexado (não cliente) | Sim  |  |
+| High Green Power | Fixo | Sim  |  |
+| Tesla | Fixo | Sim |  |
+| ACP Electric by EVIO - sócio ACP | Fixo | Sim  |  |
+| EVIO | Fixo | Sim  |  |
+| Prio Electric | Fixo | Sim  | Sim |
+| Via Verde Electric | Fixo | Sim |  |
+| Cartão EDP Charge | Fixo | Sim |  |
+| Continente Plug & Charge | Fixo |  | Sim |
+| Miio | Fixo | Sim |  |
 
 ## Links Úteis
 


### PR DESCRIPTION
Por lapso meu, não reparei que o site ocarroeletrico.com não representa corretamente o icon na tabela.

![image](https://github.com/user-attachments/assets/c4898d7d-f211-4cbb-9de6-1588d5e1cd35)
